### PR TITLE
PLAT-3881 Add ability to publish to gemfury

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
       - checkout
       - run: make install-tox
       - run: tox -e py3
+  publish-to-gemfury:
+    executor: python
+    steps:
+      - checkout
+      - run: ci/publish
 
 workflows:
   version: 2
@@ -44,5 +49,15 @@ workflows:
                 - "3.8"
                 - "3.7"
           filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+/
+      - publish-to-gemfury:
+          context: musekafka-publish
+          requires:
+            - lint
+            - test
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+/

--- a/ci/publish
+++ b/ci/publish
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+pip3 install wheel twine
+
+# create source distribution and build pure python wheel
+python3 setup.py sdist bdist_wheel
+
+twine upload dist/* --repository-url https://push.fury.io/themuse -p ""


### PR DESCRIPTION
Add ci/publish script and publish-to-gemfury step to publish to gemfury on version-like tags.

NOTE: This published package is public, just like this repository.

PLAT-3881